### PR TITLE
GMMS-3134: [Android] When long text entered for custom attributes blocks the start chat icon

### DIFF
--- a/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
+++ b/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
@@ -39,7 +39,7 @@
                 android:id="@+id/deploymentIdEditText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint= "@string/quick_start_account_form_account_name" />
+                android:hint="@string/quick_start_account_form_account_name" />
 
             <androidx.appcompat.widget.AppCompatEditText
                 android:id="@+id/domainNameEditText"

--- a/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
+++ b/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
@@ -23,38 +23,53 @@
         android:textSize="22sp"
         android:layout_margin="10dp"/>
 
-    <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/deploymentIdEditText"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint= "@string/quick_start_account_form_account_name" />
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
-    <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/domainNameEditText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/quick_start_account_form_knowledge_base" />
+        <LinearLayout
+            android:id="@+id/account_fields"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="visible">
 
-    <androidx.appcompat.widget.AppCompatEditText
-        android:id="@+id/customAttributesEditText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/quick_start_account_form_custom_attributes" />
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/deploymentIdEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint= "@string/quick_start_account_form_account_name" />
 
-    <androidx.appcompat.widget.SwitchCompat
-        android:id="@+id/loggingSwitch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:enabled="true"
-        android:padding="6sp"
-        android:text="@string/quick_start_account_form_logging"
-        android:textSize="16sp"
-        android:layout_marginTop="6dp"/>
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/domainNameEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/quick_start_account_form_knowledge_base" />
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/customAttributesEditText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/quick_start_account_form_custom_attributes" />
+
+        <androidx.appcompat.widget.SwitchCompat
+            android:id="@+id/loggingSwitch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="true"
+            android:padding="6sp"
+            android:text="@string/quick_start_account_form_logging"
+            android:textSize="16sp"
+            android:layout_marginTop="6dp"/>
+
+        </LinearLayout>
+    </ScrollView>
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center|bottom"
+        android:layout_height="wrap_content"
+        android:gravity="bottom"
         android:orientation="vertical">
 
         <TextView

--- a/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
+++ b/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
@@ -18,7 +18,7 @@
     <androidx.appcompat.widget.AppCompatTextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Account Details"
+        android:text="@string/title_details"
         android:textColor="@color/black"
         android:textSize="22sp"
         android:layout_margin="10dp"/>
@@ -50,7 +50,6 @@
         android:text="@string/quick_start_account_form_logging"
         android:textSize="16sp"
         android:layout_marginTop="6dp"/>
-
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
+++ b/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
@@ -69,7 +69,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="bottom"
+        android:gravity="center|bottom"
         android:orientation="vertical">
 
         <TextView

--- a/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
+++ b/GCMessengerSDKSample/app/src/main/res/layout/fragment_chat_form.xml
@@ -35,33 +35,33 @@
             android:orientation="vertical"
             android:visibility="visible">
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/deploymentIdEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint= "@string/quick_start_account_form_account_name" />
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/deploymentIdEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint= "@string/quick_start_account_form_account_name" />
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/domainNameEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/quick_start_account_form_knowledge_base" />
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/domainNameEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/quick_start_account_form_knowledge_base" />
 
-        <androidx.appcompat.widget.AppCompatEditText
-            android:id="@+id/customAttributesEditText"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:hint="@string/quick_start_account_form_custom_attributes" />
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/customAttributesEditText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/quick_start_account_form_custom_attributes" />
 
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/loggingSwitch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:enabled="true"
-            android:padding="6sp"
-            android:text="@string/quick_start_account_form_logging"
-            android:textSize="16sp"
-            android:layout_marginTop="6dp"/>
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/loggingSwitch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:enabled="true"
+                android:padding="6sp"
+                android:text="@string/quick_start_account_form_logging"
+                android:textSize="16sp"
+                android:layout_marginTop="6dp"/>
 
         </LinearLayout>
     </ScrollView>

--- a/GCMessengerSDKSample/app/src/main/res/values/strings.xml
+++ b/GCMessengerSDKSample/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Genesys Cloud Mobile Messenger</string>
     <string name="app_version">Version: %1$s (%2$d)</string>
+    <string name="title_details">Account Details</string>
     <string name="title_activity_main2">MainActivity2</string>
     <string name="title_home">Home</string>
     <string name="title_dashboard">Dashboard</string>


### PR DESCRIPTION
Before the fix:
![sample_app](https://github.com/user-attachments/assets/08292aef-2b7b-498f-b676-41b57d1bf812)
After the fix:
![content_scroll_fixed_](https://github.com/user-attachments/assets/2e9402b5-6b40-48b9-8321-932b9c821904)

