### PR TITLE
GMMS-10492 [Android][Sample App] : Leading / trailing spaces in Sample App input fields should be trimmed

### DIFF
--- a/GCMessengerSDKSample/app/src/main/java/com/genesys/cloud/messenger/sample/chat_form/ChatFormFragment.kt
+++ b/GCMessengerSDKSample/app/src/main/java/com/genesys/cloud/messenger/sample/chat_form/ChatFormFragment.kt
@@ -101,8 +101,8 @@ class ChatFormFragment : Fragment() {
     private fun setAccountEditTextValue(editText: AppCompatEditText, text: String?) {
         editText.setText(text)
         editText.doOnTextChanged { _, _, _, _ ->
-            val deploymentId = binding.deploymentIdEditText.text.toString()
-            val domain = binding.domainNameEditText.text.toString()
+            val deploymentId = binding.deploymentIdEditText.text.toString().trim()
+            val domain = binding.domainNameEditText.text.toString().trim()
 
             setLoginButtonState(deploymentId, domain)
         }


### PR DESCRIPTION
Extra spaces are not ignored and chat could not be started → Extra spaces should be ignored